### PR TITLE
assigning Windows Error Reporting\\Disabled a default value

### DIFF
--- a/lists.php
+++ b/lists.php
@@ -685,4 +685,5 @@ $defaultRegKeys = [
     "BypassSecureBootCheck" => [null],
     "SV2" => [null],
     "Win32PrioritySeparation" => [2],
+    "Windows Error Reporting\\Disabled" => [null]
 ];

--- a/viewer.php
+++ b/viewer.php
@@ -1858,7 +1858,7 @@ $pupsfoundRunning = array_filter($referenceListRunning, function($checkobj) use 
                         <div class="textbox metadata-detail" id="accordionTablesDevices">
                             <div class="accordion">
                                 <h1 class="accordion-header" id="devicesTableButton">
-                                    <button class="accordion-button" type="button" data-mdb-toggle="collapse" data-mdb-target="#devices" aria-expanded="true" aria-controls="devices">
+                                    <button class="accordion-button collapsed" type="button" data-mdb-toggle="collapse" data-mdb-target="#devices" aria-expanded="true" aria-controls="devices">
                                         Devices
                                     </button>
                                 </h1>
@@ -1873,7 +1873,7 @@ $pupsfoundRunning = array_filter($referenceListRunning, function($checkobj) use 
                                     </table>
                                 </div>
                                 <h1 class="accordion-header" id="driversTableButton">
-                                    <button class="accordion-button" type="button" data-mdb-toggle="collapse" data-mdb-target="#drivers" aria-expanded="true" aria-controls="drivers">
+                                    <button class="accordion-button collapsed" type="button" data-mdb-toggle="collapse" data-mdb-target="#drivers" aria-expanded="true" aria-controls="drivers">
                                         Drivers
                                     </button>
                                 </h1>
@@ -1895,7 +1895,7 @@ $pupsfoundRunning = array_filter($referenceListRunning, function($checkobj) use 
                         <div class="textbox metadata-detail" id="accordionTablesApps">
                             <div class="accordion">
                                 <h1 class="accordion-header" id="runningProcessesButton">
-                                    <button class="accordion-button" type="button" data-mdb-toggle="collapse" data-mdb-target="#runningProcesses" aria-expanded="true" aria-controls="runningProcesses">
+                                    <button class="accordion-button collapsed" type="button" data-mdb-toggle="collapse" data-mdb-target="#runningProcesses" aria-expanded="true" aria-controls="runningProcesses">
                                         Running Processes
                                     </button>
                                 </h1>
@@ -1911,7 +1911,7 @@ $pupsfoundRunning = array_filter($referenceListRunning, function($checkobj) use 
                                     </table>
                                 </div>
                                 <h1 class="accordion-header" id="installedAppButton">
-                                    <button class="accordion-button" type="button" data-mdb-toggle="collapse" data-mdb-target="#installedApp" aria-expanded="true" aria-controls="installedApp">
+                                    <button class="accordion-button collapsed" type="button" data-mdb-toggle="collapse" data-mdb-target="#installedApp" aria-expanded="true" aria-controls="installedApp">
                                         Installed Apps
                                     </button>
                                 </h1>
@@ -1932,7 +1932,7 @@ $pupsfoundRunning = array_filter($referenceListRunning, function($checkobj) use 
                         <div class="textbox metadata-detail" id="accordionTablesServices">
                             <div class="accordion">
                                 <h1 class="accordion-header" id="servicesTableButton">
-                                    <button class="accordion-button" type="button" data-mdb-toggle="collapse" data-mdb-target="#services" aria-expanded="true" aria-controls="services">
+                                    <button class="accordion-button collapsed" type="button" data-mdb-toggle="collapse" data-mdb-target="#services" aria-expanded="true" aria-controls="services">
                                         Services
                                     </button>
                                 </h1>
@@ -1948,7 +1948,7 @@ $pupsfoundRunning = array_filter($referenceListRunning, function($checkobj) use 
                                     </table>
                                 </div>
                                 <h1 class="accordion-header" id="tasksTableButton">
-                                    <button class="accordion-button" type="button" data-mdb-toggle="collapse" data-mdb-target="#tasks" aria-expanded="true" aria-controls="tasks">
+                                    <button class="accordion-button collapsed" type="button" data-mdb-toggle="collapse" data-mdb-target="#tasks" aria-expanded="true" aria-controls="tasks">
                                         Tasks
                                     </button>
                                 </h1>
@@ -1972,7 +1972,7 @@ $pupsfoundRunning = array_filter($referenceListRunning, function($checkobj) use 
                         <div class="textbox metadata-detail" id="accordionTablesNetwork">
                             <div class="accordion">
                                 <h1 class="accordion-header" id="netconTableButton">
-                                    <button class="accordion-button" type="button" data-mdb-toggle="collapse" data-mdb-target="#netcon" aria-expanded="true" aria-controls="netcon">
+                                    <button class="accordion-button collapsed" type="button" data-mdb-toggle="collapse" data-mdb-target="#netcon" aria-expanded="true" aria-controls="netcon">
                                         Network Connections
                                     </button>
                                 </h1>
@@ -1988,7 +1988,7 @@ $pupsfoundRunning = array_filter($referenceListRunning, function($checkobj) use 
                                     </table>
                                 </div>
                                 <h1 class="accordion-header" id="routesTableButton">
-                                    <button class="accordion-button" type="button" data-mdb-toggle="collapse" data-mdb-target="#routes" aria-expanded="true" aria-controls="routes">
+                                    <button class="accordion-button collapsed" type="button" data-mdb-toggle="collapse" data-mdb-target="#routes" aria-expanded="true" aria-controls="routes">
                                         Routes Table
                                     </button>
                                 </h1>
@@ -2005,7 +2005,7 @@ $pupsfoundRunning = array_filter($referenceListRunning, function($checkobj) use 
                                     </table>
                                 </div>
                                 <h1 class="accordion-header" id="hostsTableButton">
-                                    <button class="accordion-button" type="button" data-mdb-toggle="collapse" data-mdb-target="#hosts" aria-expanded="true" aria-controls="hosts">
+                                    <button class="accordion-button collapsed" type="button" data-mdb-toggle="collapse" data-mdb-target="#hosts" aria-expanded="true" aria-controls="hosts">
                                         Hosts File
                                     </button>
                                 </h1>
@@ -2022,7 +2022,7 @@ $pupsfoundRunning = array_filter($referenceListRunning, function($checkobj) use 
                         <div class="textbox metadata-detail" id="accordionTablesDev">
                             <div class="accordion">
                                 <h1 class="accordion-header" id="debugLogButton">
-                                    <button class="accordion-button" type="button" data-mdb-toggle="collapse" data-mdb-target="#debugLog" aria-expanded="true" aria-controls="debugLog">
+                                    <button class="accordion-button collapsed" type="button" data-mdb-toggle="collapse" data-mdb-target="#debugLog" aria-expanded="true" aria-controls="debugLog">
                                         Debug Log
                                     </button>
                                 </h1>


### PR DESCRIPTION
Viewer crashes when `Windows Error Reporting\\Disabled` is set to anything other than null, as seen in this profile:

https://spec-ify.com/profile/5ef9ee9f

I don't know how we haven't caught this before the v1.3.0 release lol