### PR TITLE
Updated lists.php to include the AOMEI suite

### DIFF
--- a/lists.php
+++ b/lists.php
@@ -59,7 +59,7 @@
         "Rainmeter",    // Theming tool, can cause UI issues - martin311
         "TaskbarX",    // Theming tool, can cause UI issues - martin311
         "OpenShell",    // Theming tool, can cause UI issues - martin311
-        "AOMEI",       // Catch-all for the AOMEI software suite, can cause OS issues - exstacydemon
+        "AOMEI"       // Catch-all for the AOMEI software suite, can cause OS issues - exstacydemon
     ];
 
     $biosCharacteristics = [

--- a/lists.php
+++ b/lists.php
@@ -58,7 +58,8 @@
         "Windhawk",      // Theming tool, can cause UI issues - exstacy
         "Rainmeter",    // Theming tool, can cause UI issues - martin311
         "TaskbarX",    // Theming tool, can cause UI issues - martin311
-        "OpenShell"    // Theming tool, can cause UI issues - martin311
+        "OpenShell",    // Theming tool, can cause UI issues - martin311
+        "AOMEI",       // Catch-all for the AOMEI software suite, can cause OS issues - exstacydemon
     ];
 
     $biosCharacteristics = [


### PR DESCRIPTION
Updated lists.php to add the AOMEI suite of software to the list of notable software as the backup software is known to cause potential crashes on systems with it installed, and its cloning/MBR to GPT software is self explanatory. 