### PR TITLE
update URL to a direct download

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,11 +46,11 @@
                 </form>
 
             </section>
-            <nav><a class="link" href="https://github.com/Spec-ify/specify/releases" target="_blank">
+            <nav><a class="link" href="https://github.com/Spec-ify/specify/releases/latest/download/Specify_noring0.exe" target="_blank">
 
                 <div class="link-title">
                         <img height="45em"src="assets/dl.png">
-                    <h3>Downloads</h3></div>
+                    <h3>Download</h3></div>
                 <div class="link-description">Download the latest version of Specify.</div>
             </a></nav>
 


### PR DESCRIPTION
The download URL previously went to the releases page, I believe this is an uneeded step, we can link to the latest release directly. We already have links to the Github in the next block.