### PR TITLE
Update download link for Specify executable

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
                 </form>
 
             </section>
-            <nav><a class="link" href="https://github.com/Spec-ify/specify/releases/latest/download/Specify_noring0.exe" target="_blank">
+            <nav><a class="link" href="https://github.com/Spec-ify/specify/releases/latest/download/Specify.exe" target="_blank">
 
                 <div class="link-title">
                         <img height="45em"src="assets/dl.png">


### PR DESCRIPTION
This points back to the main Specify.exe instead of noring since we are only skipping noring